### PR TITLE
Update build instructions for Titus control plane

### DIFF
--- a/docs/docs/build.md
+++ b/docs/docs/build.md
@@ -12,14 +12,7 @@ cd titus-api-definitions
 ./gradlew clean build
 ```
 
-# Titus Master
-```
-git clone https://github.com/Netflix/titus-control-plane.git
-cd titus-control-plane
-./gradlew clean buildDeb -PidlLocal
-```
-
-# Titus Gateway
+# Titus Control Plane
 ```
 git clone https://github.com/Netflix/titus-control-plane.git
 cd titus-control-plane
@@ -28,3 +21,9 @@ cd titus-control-plane
 
 **Note:** the `titus-api-definitions` git repo must be in the same root folder as `titus-control-plane` git repo in order to build the master and gateway components with `-PidlLocal`.
 Running all builds will produce 5 debs under the build/distributions folder in each component.
+
+For example the gateway deb can be found as follows:
+```
+$ ls titus-server-gateway/build/distributions/*.deb
+titus-server-gateway/build/distributions/titus-server-gateway_0.0.1-1_all.deb
+```


### PR DESCRIPTION
The instructions for building the master and gateway components were identical.  Issuing the single 
```bash
$ ./gradlew clean buildDeb -PidlLocal
```
is sufficient to build debs for the master and gateway components, so the documentation was redundant.